### PR TITLE
Rename some stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Inspired by [Elixir's `cond`](https://elixir-lang.org/getting-started/case-cond-and-if.html#cond) this is a simpler alternative to [lodash's `_.cond`](https://lodash.com/docs/4.17.15#cond)
 
-[![codecov](https://codecov.io/gh/erikmueller/cond-flow/branch/master/graph/badge.svg)](https://codecov.io/gh/erikmueller/cond-flow)
+[![codecov](https://codecov.io/gh/erikmueller/cond-flow/branch/master/graph/badge.svg?token=WCNYJSZK51)](https://codecov.io/gh/erikmueller/cond-flow)
 
 ## Install
 
@@ -32,7 +32,7 @@ const value = cond([
 // value === 'true'
 ```
 
-Also works nicely with React components as you can have the values lazily evaluated by wrapping it in a function:
+Also works nicely with React components as you can have the values lazily evaluated by wrapping them in a function:
 
 ```jsx
 import cond from 'cond-flow'
@@ -48,9 +48,9 @@ const Component = ({ isDisabled, isNew, isLoading }) => (
 )
 ```
 
-### Fallback
+### Default return value
 
-You can provide a fallback which will be returned if no provided conditions are met.
+You can provide a `default` fallback which will be returned if no provided conditions are met.
 
 ```js
 import cond from 'cond-flow'
@@ -60,7 +60,7 @@ const value = cond(
     [false, () => 'false'],
     [false, () => 'also false'],
   ],
-  { fallback: () => 'fallback' },
+  { default: () => 'fallback' },
 )
 
 // value === 'fallback'

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -19,7 +19,7 @@ it("returns undefined if no predicate evaluates to true", () => {
 
 it("returns provided fallback if no predicate evaluates to true", () => {
 	const value = cond([[false, "false"]], {
-		fallback: () => "fallback",
+		default: () => "fallback",
 	});
 
 	expect(value).toBe("fallback");

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,10 @@ type Pairs<T> = [boolean, Value<T>][];
 
 type Options<T> = {
 	/**
-	 * If no match is found, the fallback is returned instead.
+	 * If no match is found, the default is returned instead.
 	 * @default undefined
 	 */
-	fallback?: Value<T>;
+	default?: Value<T>;
 };
 
 // Ignoring rule to allow for usage of interface
@@ -16,7 +16,7 @@ interface Cond {
 	<T, F extends undefined>(pairs: Pairs<T>, options?: F): T | undefined;
 	<T, F extends Value<T>>(
 		pairs: Pairs<T>,
-		options?: { fallback: F },
+		options?: { default: F },
 	): F extends Value<T> ? T : T | undefined;
 	<T>(pairs: Pairs<T>, options?: Options<T>): T | undefined;
 }
@@ -32,7 +32,7 @@ function processMatch<T>(match: Value<T>): T {
 
 const cond: Cond = <T, F>(pairs: Pairs<T>, options?: Options<F>) => {
 	const found = pairs.find(([predicate]) => predicate);
-	const match = found === undefined ? options?.fallback : found[1];
+	const match = found === undefined ? options?.default : found[1];
 
 	return processMatch(match);
 };


### PR DESCRIPTION
It feels a bit more natural to call the option for providing a fallback value `default` (as in `switch/case`'s `default` case)